### PR TITLE
Make OMODFramework aware of active BSAs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ set(enable_warnings OFF)
 add_library(dummy_cs_project SHARED DummyCSFile.cs)
 set_target_properties(dummy_cs_project PROPERTIES
 	LINKER_LANGUAGE CSharp
-	VS_PACKAGE_REFERENCES "OMODFramework_2.1.0.2;OMODFramework.Scripting_2.1.0.2;RtfPipe_1.0.7388.1242"
+	VS_PACKAGE_REFERENCES "OMODFramework_2.2.0;OMODFramework.Scripting_2.2.0;RtfPipe_1.0.7388.1242"
 )
 
 if(DEFINED DEPENDENCIES_DIR)

--- a/src/installer_omod_en.ts
+++ b/src/installer_omod_en.ts
@@ -51,106 +51,106 @@
 <context>
     <name>OMODFrameworkWrapper</name>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="293"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="328"/>
         <source>%1 wants to change [%2] %3 from &quot;%4&quot; to &quot;%5&quot;</source>
         <extracomment>%1 is the mod name [%2] is the ini section name. %3 is the ini setting name. %4 is the value already in Oblivion.ini. %5 is the value the mod wants to set.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="302"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="337"/>
         <source>%1 wants to set [%2] %3 to &quot;%4&quot;</source>
         <extracomment>%1 is the mod name [%2] is the ini section name. %3 is the ini setting name. %5 is the value the mod wants to set.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="305"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="340"/>
         <source>Update INI?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="396"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="431"/>
         <source>%1 has data for %2, but Mod Organizer 2 doesn&apos;t know what to do with it yet. Please report this to the Mod Organizer 2 development team (ideally by sending us your interface log) as we didn&apos;t find any OMODs that actually did this, and we need to know that they exist.</source>
         <extracomment>%1 is the mod name %2 is the name of a field in the OMOD&apos;s return data Hopefully this message will never be seen by anyone, but if it is, they need to know to tell the Mod Organizer 2 dev team.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="399"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="434"/>
         <source>Mod Organizer 2 can&apos;t completely install this OMOD.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="481"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="516"/>
         <source>Activate mod?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="485"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="520"/>
         <source>%1 contains the OMOD %2. OMODs may have post-installation actions like activating ESPs. Would you like to enable the mod so this can happen now?</source>
         <extracomment>%1 is the left-pane mod name. %2 is the name from the metadata of an OMOD.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="515"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="550"/>
         <source>%1 wants to activate %2. Do you want to do so?</source>
         <extracomment>%1 is the mod name. %2 is the plugin name.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="517"/>
-        <location filename="OMODFrameworkWrapper.cpp" line="560"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="552"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="595"/>
         <source>Activate plugin?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="529"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="564"/>
         <source>OMOD wants to activate missing plugin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="529"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="564"/>
         <source>An OMOD wants to activate a missing plugin. This shouldn&apos;t be possible. Please report this to a MO2 developer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="558"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="593"/>
         <source>%1 installed %2, but doesn&apos;t activate it by default. Do you want to activate it anyway?</source>
         <extracomment>%1 is the mod name. %2 is the plugin name.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="572"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="607"/>
         <source>OMOD claimed to install missing plugin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="572"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="607"/>
         <source>An OMOD has activation settings for a missing plugin. This shouldn&apos;t be possible. Please report this to a MO2 developer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="594"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="629"/>
         <source>Register BSAs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="598"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="633"/>
         <source>%1 wants to register the following BSA archives, but Mod Organizer 2 can&apos;t do that yet due to technical limitations:&lt;ul&gt;&lt;li&gt;%2&lt;/li&gt;&lt;/ul&gt;For now, your options include adding the BSA names to &lt;code&gt;sResourceArchiveList&lt;/code&gt; in the game INI, creating a dummy ESP with the same name, or extracting the BSA, all of which have drawbacks.</source>
         <extracomment>%1 is the OMOD name &lt;ul&gt;&lt;li&gt;%2&lt;/li&gt;&lt;/ul&gt; becomes a list of BSA files</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="673"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="708"/>
         <source>Display Readme?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="675"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="710"/>
         <source>The Readme may explain installation options. Display it?&lt;br&gt;It will remain visible until you close it.</source>
         <extracomment>&lt;br&gt; is a line break. Translators can remove it if it makes things clearer.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="681"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="716"/>
         <source>%1 Readme</source>
         <extracomment>%1 is the mod name</extracomment>
         <translation type="unfinished"></translation>


### PR DESCRIPTION
At least one OMOD needs to extract files from existing BSAs. Thankfully, basically everything needed for that was already in OMODFramework, and it just needed telling which BSAs were active at the time of mod installation. Annoyingly, it took them as a HashSet, so I needed to change to an ordered collection, hence the version bump. Also, MO2 won't tell plugins which BSAs are actually active, so this has to reconstruct the list. It assumes archive invalidation is active in some form or other, but MO2 has that built-in, and presumably no one's ever turned it off.

This doesn't actually fix the problematic mod as it then packs a new BSA which OMODFramework can't handle yet.