### PR TITLE
Catch and rethrow .NET exceptions in OMODFrameworkWrapper constructor

### DIFF
--- a/src/OMODFrameworkWrapper.cpp
+++ b/src/OMODFrameworkWrapper.cpp
@@ -70,17 +70,28 @@ OMODFrameworkWrapper::OMODFrameworkWrapper(MOBase::IOrganizer* organizer, QWidge
   , mParentWidget(parentWidget)
   , mWaitDialog(make_nullptr<QProgressDialog>())
 {
-  AssemblyResolver::initialise(mMoInfo);
+  try
+  {
+    AssemblyResolver::initialise(mMoInfo);
 
-  constructorHelper();
+    constructorHelper();
 
-  connect(this, &OMODFrameworkWrapper::pickModName, this, &OMODFrameworkWrapper::pickModNameSlot, Qt::ConnectionType::BlockingQueuedConnection);
-  connect(this, &OMODFrameworkWrapper::createMod, this, &OMODFrameworkWrapper::createModSlot, Qt::ConnectionType::BlockingQueuedConnection);
-  connect(this, &OMODFrameworkWrapper::displayReadme, this, &OMODFrameworkWrapper::displayReadmeSlot, Qt::ConnectionType::BlockingQueuedConnection);
-  connect(this, &OMODFrameworkWrapper::showWaitDialog, this, &OMODFrameworkWrapper::showWaitDialogSlot, Qt::ConnectionType::QueuedConnection);
-  connect(this, &OMODFrameworkWrapper::hideWaitDialog, this, &OMODFrameworkWrapper::hideWaitDialogSlot, Qt::ConnectionType::QueuedConnection);
+    connect(this, &OMODFrameworkWrapper::pickModName, this, &OMODFrameworkWrapper::pickModNameSlot, Qt::ConnectionType::BlockingQueuedConnection);
+    connect(this, &OMODFrameworkWrapper::createMod, this, &OMODFrameworkWrapper::createModSlot, Qt::ConnectionType::BlockingQueuedConnection);
+    connect(this, &OMODFrameworkWrapper::displayReadme, this, &OMODFrameworkWrapper::displayReadmeSlot, Qt::ConnectionType::BlockingQueuedConnection);
+    connect(this, &OMODFrameworkWrapper::showWaitDialog, this, &OMODFrameworkWrapper::showWaitDialogSlot, Qt::ConnectionType::QueuedConnection);
+    connect(this, &OMODFrameworkWrapper::hideWaitDialog, this, &OMODFrameworkWrapper::hideWaitDialogSlot, Qt::ConnectionType::QueuedConnection);
 
-  initFrameworkSettings();
+    initFrameworkSettings();
+  }
+  catch (const std::exception& e)
+  {
+    throw;
+  }
+  catch (System::Exception^ dotNetException)
+  {
+    throw toStdException(dotNetException);
+  }
 }
 
 void OMODFrameworkWrapper::constructorHelper()


### PR DESCRIPTION
Otherwise things like trying to load OMODFramework DLLs with a zone identifier (e.g. because I've asked someone to try something with a modified version to debug an issue) will generate a .NET exception and crash MO2, producing an undebuggable crash dump. Mixed mode and native see only external code, and managed insists the crash is in native code without preserving the exception that native code threw.

I'd be happier if this made it into 2.4.2, but I've not got a MO2 build system on my new PC yet, so can't test it - I've not even compiled this yet. To test this, the good case is that loading normally loads normally, and the bad case is that the modified and not unblocked OMODFramework DLLs from #troubleshooting on Discord successfully generates a log entry or popup or something explaining what died - it should be an exception message with a link to https://docs.microsoft.com/en-us/previous-versions/dotnet/netframework-4.0/dd409252(v=vs.100)?redirectedfrom=MSDN