### PR TITLE
Bump OMODFramework to 2.2.1 to fix a crash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ set(enable_warnings OFF)
 add_library(dummy_cs_project SHARED DummyCSFile.cs)
 set_target_properties(dummy_cs_project PROPERTIES
 	LINKER_LANGUAGE CSharp
-	VS_PACKAGE_REFERENCES "OMODFramework_2.2.0;OMODFramework.Scripting_2.2.0;RtfPipe_1.0.7388.1242"
+	VS_PACKAGE_REFERENCES "OMODFramework_2.2.1;OMODFramework.Scripting_2.2.1;RtfPipe_1.0.7388.1242"
 )
 
 if(DEFINED DEPENDENCIES_DIR)


### PR DESCRIPTION
BSAs with zero-length folder names (I'm presuming where there are consecutive backslashes in a path) caused a negative-length read from a file. Now they don't.

As this fixes a crash, it should go in 2.4.2 if at all possible.