### PR TITLE
Ensure default OMODFramework log isn't created

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ set(enable_warnings OFF)
 add_library(dummy_cs_project SHARED DummyCSFile.cs)
 set_target_properties(dummy_cs_project PROPERTIES
 	LINKER_LANGUAGE CSharp
-	VS_PACKAGE_REFERENCES "OMODFramework_2.2.1;OMODFramework.Scripting_2.2.1;RtfPipe_1.0.7388.1242"
+	VS_PACKAGE_REFERENCES "OMODFramework_2.2.2;OMODFramework.Scripting_2.2.2;RtfPipe_1.0.7388.1242"
 )
 
 if(DEFINED DEPENDENCIES_DIR)

--- a/src/OMODFrameworkWrapper.cpp
+++ b/src/OMODFrameworkWrapper.cpp
@@ -658,10 +658,10 @@ void OMODFrameworkWrapper::initFrameworkSettings()
   OMODFramework::Framework::Settings->DllPath = System::IO::Path::Combine(System::IO::Path::GetDirectoryName(OMODFramework::Framework::Settings->DllPath), "OMODFramework.Scripting.dll");
 
   OMODFramework::LoggingSettings^ loggingSettings = OMODFramework::Framework::Settings->LoggingSettings;
-  loggingSettings->UseLogger = true;
   loggingSettings->LogToFile = false;
   loggingSettings->LowestLoggingLevel = Logger::OMODLoggingLevel(MOBase::log::getDefault().level());
   loggingSettings->Logger = gcnew Logger();
+  loggingSettings->UseLogger = true;
 
   OMODFramework::ScriptExecutionSettings^ scriptSettings = gcnew OMODFramework::ScriptExecutionSettings();
   scriptSettings->EnableWarnings = true;


### PR DESCRIPTION
The default location is in the same directory as the OMODFramework DLL. That doesn't work when MO2 is installed to Program Files.