### PR TITLE
Fix in-place edits to files being installed

### DIFF
--- a/src/OMODFrameworkWrapper.cpp
+++ b/src/OMODFrameworkWrapper.cpp
@@ -274,7 +274,9 @@ OMODFrameworkWrapper::EInstallResult OMODFrameworkWrapper::install(MOBase::Guess
         OMODFramework::Framework::LoadBSAs(activeBSAs);
         scope_guard bsaGuard([]() { OMODFramework::Framework::ClearBSAs(); });
 
-        OMODFramework::ScriptReturnData^ scriptData = OMODFramework::Scripting::ScriptRunner::RunScript(%omod, scriptFunctions);
+        System::String^ dataPath = omod.GetDataFiles();
+        System::String^ pluginsPath = omod.GetPlugins();
+        OMODFramework::ScriptReturnData^ scriptData = OMODFramework::Scripting::ScriptRunner::RunScript(%omod, scriptFunctions, dataPath, pluginsPath);
         if (!scriptData)
           throw std::runtime_error("OMOD script returned no result. This isn't supposed to happen.");
         if (scriptData->CancelInstall)
@@ -368,7 +370,7 @@ OMODFrameworkWrapper::EInstallResult OMODFrameworkWrapper::install(MOBase::Guess
           }
         }
 
-        scriptData->Pretty(%omod, omod.GetDataFiles(), omod.GetPlugins());
+        scriptData->Pretty(%omod, dataPath, pluginsPath);
         // no compatability between auto and var makes me :angery:
         System::Collections::Generic::HashSet<System::String^>^ installedPlugins = gcnew System::Collections::Generic::HashSet<System::String^>(System::StringComparer::InvariantCultureIgnoreCase);
         for each (OMODFramework::InstallFile file in scriptData->InstallFiles)

--- a/src/installerOmod.cpp
+++ b/src/installerOmod.cpp
@@ -46,7 +46,7 @@ QString InstallerOMOD::description() const
 
 MOBase::VersionInfo InstallerOMOD::version() const
 {
-  return MOBase::VersionInfo(1, 0, 0, MOBase::VersionInfo::RELEASE_PREALPHA);
+  return MOBase::VersionInfo(1, 1, 0, 0);
 }
 
 std::vector<std::shared_ptr<const MOBase::IPluginRequirement>> InstallerOMOD::requirements() const

--- a/src/installerOmod.cpp
+++ b/src/installerOmod.cpp
@@ -46,7 +46,7 @@ QString InstallerOMOD::description() const
 
 MOBase::VersionInfo InstallerOMOD::version() const
 {
-  return MOBase::VersionInfo(1, 1, 0, 0);
+  return MOBase::VersionInfo(1, 1, 0, MOBase::VersionInfo::RELEASE_FINAL);
 }
 
 std::vector<std::shared_ptr<const MOBase::IPluginRequirement>> InstallerOMOD::requirements() const

--- a/src/installer_omod_en.ts
+++ b/src/installer_omod_en.ts
@@ -51,106 +51,106 @@
 <context>
     <name>OMODFrameworkWrapper</name>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="339"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="341"/>
         <source>%1 wants to change [%2] %3 from &quot;%4&quot; to &quot;%5&quot;</source>
         <extracomment>%1 is the mod name [%2] is the ini section name. %3 is the ini setting name. %4 is the value already in Oblivion.ini. %5 is the value the mod wants to set.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="348"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="350"/>
         <source>%1 wants to set [%2] %3 to &quot;%4&quot;</source>
         <extracomment>%1 is the mod name [%2] is the ini section name. %3 is the ini setting name. %5 is the value the mod wants to set.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="351"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="353"/>
         <source>Update INI?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="442"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="444"/>
         <source>%1 has data for %2, but Mod Organizer 2 doesn&apos;t know what to do with it yet. Please report this to the Mod Organizer 2 development team (ideally by sending us your interface log) as we didn&apos;t find any OMODs that actually did this, and we need to know that they exist.</source>
         <extracomment>%1 is the mod name %2 is the name of a field in the OMOD&apos;s return data Hopefully this message will never be seen by anyone, but if it is, they need to know to tell the Mod Organizer 2 dev team.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="445"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="447"/>
         <source>Mod Organizer 2 can&apos;t completely install this OMOD.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="527"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="529"/>
         <source>Activate mod?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="531"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="533"/>
         <source>%1 contains the OMOD %2. OMODs may have post-installation actions like activating ESPs. Would you like to enable the mod so this can happen now?</source>
         <extracomment>%1 is the left-pane mod name. %2 is the name from the metadata of an OMOD.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="561"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="563"/>
         <source>%1 wants to activate %2. Do you want to do so?</source>
         <extracomment>%1 is the mod name. %2 is the plugin name.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="563"/>
-        <location filename="OMODFrameworkWrapper.cpp" line="606"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="565"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="608"/>
         <source>Activate plugin?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="575"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="577"/>
         <source>OMOD wants to activate missing plugin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="575"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="577"/>
         <source>An OMOD wants to activate a missing plugin. This shouldn&apos;t be possible. Please report this to a MO2 developer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="604"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="606"/>
         <source>%1 installed %2, but doesn&apos;t activate it by default. Do you want to activate it anyway?</source>
         <extracomment>%1 is the mod name. %2 is the plugin name.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="618"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="620"/>
         <source>OMOD claimed to install missing plugin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="618"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="620"/>
         <source>An OMOD has activation settings for a missing plugin. This shouldn&apos;t be possible. Please report this to a MO2 developer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="640"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="642"/>
         <source>Register BSAs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="644"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="646"/>
         <source>%1 wants to register the following BSA archives, but Mod Organizer 2 can&apos;t do that yet due to technical limitations:&lt;ul&gt;&lt;li&gt;%2&lt;/li&gt;&lt;/ul&gt;For now, your options include adding the BSA names to &lt;code&gt;sResourceArchiveList&lt;/code&gt; in the game INI, creating a dummy ESP with the same name, or extracting the BSA, all of which have drawbacks.</source>
         <extracomment>%1 is the OMOD name &lt;ul&gt;&lt;li&gt;%2&lt;/li&gt;&lt;/ul&gt; becomes a list of BSA files</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="719"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="721"/>
         <source>Display Readme?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="721"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="723"/>
         <source>The Readme may explain installation options. Display it?&lt;br&gt;It will remain visible until you close it.</source>
         <extracomment>&lt;br&gt; is a line break. Translators can remove it if it makes things clearer.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="727"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="729"/>
         <source>%1 Readme</source>
         <extracomment>%1 is the mod name</extracomment>
         <translation type="unfinished"></translation>


### PR DESCRIPTION
Calling Pretty with GetDataFiles() and GetPlugins() was causing the
files to be extracted again and most of the work done by the script
to be thrown away.