### PR TITLE
Isolate the plugin in a single folder

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,7 +48,7 @@ target_compile_definitions(installer_omod PRIVATE "NOGDI")
 # aren't pulled in. We do need it to build first, though.
 add_dependencies(installer_omod dummy_cs_project)
 
-mo2_install_target(installer_omod)
+mo2_install_target(installer_omod FOLDER)
 
 install(
 	FILES
@@ -57,7 +57,7 @@ install(
 	"$<TARGET_FILE_DIR:${PROJECT_NAME}>/ICSharpCode.SharpZipLib.dll"
 	"$<TARGET_FILE_DIR:${PROJECT_NAME}>/System.Drawing.Common.dll"
 	"$<TARGET_FILE_DIR:${PROJECT_NAME}>/RtfPipe.dll"
-	DESTINATION "${MO2_INSTALL_PATH}/bin/plugins/data"
+	DESTINATION "${MO2_INSTALL_PATH}/bin/plugins/installer_omod/"
 )
 install(
 	FILES "$<TARGET_PDB_FILE_DIR:${PROJECT_NAME}>/ICSharpCode.SharpZipLib.pdb"

--- a/src/OMODFrameworkWrapper.cpp
+++ b/src/OMODFrameworkWrapper.cpp
@@ -4,6 +4,7 @@ using namespace cli;
 
 #include <algorithm>
 #include <array>
+#include <filesystem>
 
 #include <QMessageBox>
 #include <QTemporaryDir>
@@ -32,6 +33,28 @@ using namespace cli;
 
 #include "MessageBoxHelper.h"
 
+namespace fs = std::filesystem;
+
+// retrieve the path to the folder containing the proxy DLL
+fs::path getPluginFolder()
+{
+  wchar_t path[MAX_PATH];
+  HMODULE hm = NULL;
+
+  if (GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                            GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                        (LPCWSTR)&getPluginFolder, &hm) == 0)
+  {
+    return {};
+  }
+  if (GetModuleFileName(hm, path, sizeof(path)) == 0)
+  {
+    return {};
+  }
+
+  return fs::path(path).parent_path();
+}
+
 // We want to search the plugin data directory for .NET DLLs
 class AssemblyResolver
 {
@@ -42,7 +65,7 @@ public:
   {
     if (sInitialised)
       return;
-    sPluginDataPath = organizer->pluginDataPath();
+    sPluginDataPath = getPluginFolder();
     System::AppDomain::CurrentDomain->AssemblyResolve += gcnew System::ResolveEventHandler(&OnAssemblyResolve);
     sInitialised = true;
   }

--- a/src/installer_omod_en.ts
+++ b/src/installer_omod_en.ts
@@ -51,106 +51,106 @@
 <context>
     <name>OMODFrameworkWrapper</name>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="341"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="364"/>
         <source>%1 wants to change [%2] %3 from &quot;%4&quot; to &quot;%5&quot;</source>
         <extracomment>%1 is the mod name [%2] is the ini section name. %3 is the ini setting name. %4 is the value already in Oblivion.ini. %5 is the value the mod wants to set.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="350"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="373"/>
         <source>%1 wants to set [%2] %3 to &quot;%4&quot;</source>
         <extracomment>%1 is the mod name [%2] is the ini section name. %3 is the ini setting name. %5 is the value the mod wants to set.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="353"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="376"/>
         <source>Update INI?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="444"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="467"/>
         <source>%1 has data for %2, but Mod Organizer 2 doesn&apos;t know what to do with it yet. Please report this to the Mod Organizer 2 development team (ideally by sending us your interface log) as we didn&apos;t find any OMODs that actually did this, and we need to know that they exist.</source>
         <extracomment>%1 is the mod name %2 is the name of a field in the OMOD&apos;s return data Hopefully this message will never be seen by anyone, but if it is, they need to know to tell the Mod Organizer 2 dev team.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="447"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="470"/>
         <source>Mod Organizer 2 can&apos;t completely install this OMOD.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="529"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="552"/>
         <source>Activate mod?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="533"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="556"/>
         <source>%1 contains the OMOD %2. OMODs may have post-installation actions like activating ESPs. Would you like to enable the mod so this can happen now?</source>
         <extracomment>%1 is the left-pane mod name. %2 is the name from the metadata of an OMOD.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="563"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="586"/>
         <source>%1 wants to activate %2. Do you want to do so?</source>
         <extracomment>%1 is the mod name. %2 is the plugin name.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="565"/>
-        <location filename="OMODFrameworkWrapper.cpp" line="608"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="588"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="631"/>
         <source>Activate plugin?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="577"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="600"/>
         <source>OMOD wants to activate missing plugin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="577"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="600"/>
         <source>An OMOD wants to activate a missing plugin. This shouldn&apos;t be possible. Please report this to a MO2 developer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="606"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="629"/>
         <source>%1 installed %2, but doesn&apos;t activate it by default. Do you want to activate it anyway?</source>
         <extracomment>%1 is the mod name. %2 is the plugin name.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="620"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="643"/>
         <source>OMOD claimed to install missing plugin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="620"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="643"/>
         <source>An OMOD has activation settings for a missing plugin. This shouldn&apos;t be possible. Please report this to a MO2 developer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="642"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="665"/>
         <source>Register BSAs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="646"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="669"/>
         <source>%1 wants to register the following BSA archives, but Mod Organizer 2 can&apos;t do that yet due to technical limitations:&lt;ul&gt;&lt;li&gt;%2&lt;/li&gt;&lt;/ul&gt;For now, your options include adding the BSA names to &lt;code&gt;sResourceArchiveList&lt;/code&gt; in the game INI, creating a dummy ESP with the same name, or extracting the BSA, all of which have drawbacks.</source>
         <extracomment>%1 is the OMOD name &lt;ul&gt;&lt;li&gt;%2&lt;/li&gt;&lt;/ul&gt; becomes a list of BSA files</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="721"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="744"/>
         <source>Display Readme?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="723"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="746"/>
         <source>The Readme may explain installation options. Display it?&lt;br&gt;It will remain visible until you close it.</source>
         <extracomment>&lt;br&gt; is a line break. Translators can remove it if it makes things clearer.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="729"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="752"/>
         <source>%1 Readme</source>
         <extracomment>%1 is the mod name</extracomment>
         <translation type="unfinished"></translation>


### PR DESCRIPTION
Similar to the `plugin_python` update, isolate the plugin into a folder.

Tested on 2 OMOD, so it should be fine since it simply changes where the DLLs are loaded.