### PR TITLE
Enable two-phase lookup for Qt 6.7.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,8 +36,6 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
 target_compile_options(
 	installer_omod
 	PRIVATE
-	# C++/CLI doesn't support two-phase lookup yet
-	"/Zc:twoPhase-"
 	# OMODFramework and OMODFramework.Scripting reference different .NET standard libraries. This generates warnings when using them together.
 	"/wd4691")
 


### PR DESCRIPTION
Qt 6.7 requires two-phase lookup apparently, so re-enabling it here and in the FOMOD C# installer. Plugin seems to be working as intended so I guess C++/CLR works fine with two-phase lookups now.